### PR TITLE
Replace PbSetInt with PbSetBool for chat field in c_print_to_chat_ex

### DIFF
--- a/src/chat.sp
+++ b/src/chat.sp
@@ -69,7 +69,7 @@ void c_print_to_chat_ex(int[] clients, int num_clients, const char[] msg) {
         Handle usr_msg = StartMessage("SayText2", clients, num_clients, USERMSG_RELIABLE | USERMSG_BLOCKHOOKS);
         if (GetFeatureStatus(FeatureType_Native, "GetUserMessageType") == FeatureStatus_Available && GetUserMessageType() == UM_Protobuf) {
             PbSetInt(usr_msg, "ent_idx", 0);
-            PbSetInt(usr_msg, "chat", true);
+            PbSetBool(usr_msg, "chat", true);
             PbSetString(usr_msg, "msg_name", msg);
             PbAddString(usr_msg, "params", "");
             PbAddString(usr_msg, "params", "");

--- a/src/chat.sp
+++ b/src/chat.sp
@@ -69,7 +69,10 @@ void c_print_to_chat_ex(int[] clients, int num_clients, const char[] msg) {
         Handle usr_msg = StartMessage("SayText2", clients, num_clients, USERMSG_RELIABLE | USERMSG_BLOCKHOOKS);
         if (GetFeatureStatus(FeatureType_Native, "GetUserMessageType") == FeatureStatus_Available && GetUserMessageType() == UM_Protobuf) {
             PbSetInt(usr_msg, "ent_idx", 0);
-            PbSetBool(usr_msg, "chat", true);
+            if (GetEngineVersion() == Engine_CSGO)
+                PbSetBool(usr_msg, "chat", true);
+            else
+                PbSetInt(usr_msg, "chat", true);
             PbSetString(usr_msg, "msg_name", msg);
             PbAddString(usr_msg, "params", "");
             PbAddString(usr_msg, "params", "");


### PR DESCRIPTION
On CS:GO, when an infraction is placed (or the plugin tries to use c_print_to_chat_ex()), it results in the following error and fails to print anything in the chat:

```
[SM] Exception reported: Invalid field "chat" for message "CCSUsrMsg_SayText2"
L 11/10/2021 - 04:43:24: [SM] Blaming: gflbans.smx
L 11/10/2021 - 04:43:24: [SM] Call stack trace:
L 11/10/2021 - 04:43:24: [SM]   [0] PbSetInt
L 11/10/2021 - 04:43:24: [SM]   [1] Line 72, src/chat.sp::c_print_to_chat_ex
L 11/10/2021 - 04:43:24: [SM]   [2] Line 93, src/chat.sp::c_print_to_chat
L 11/10/2021 - 04:43:24: [SM]   [3] Line 59, src/chat.sp::GFLBansChat_Announce
L 11/10/2021 - 04:43:24: [SM]   [4] Line 47, src/infractions.sp::GFLBans_ApplyPunishment
L 11/10/2021 - 04:43:24: [SM]   [5] Line 84, src/infractions.sp::GFLBans_ApplyPunishments
L 11/10/2021 - 04:43:24: [SM]   [6] Line 188, src/commands.sp::HandleChatInfraction
L 11/10/2021 - 04:43:24: [SM]   [7] Line 232, src/commands.sp::CommandListener_Mute
```

This causes a bunch of message issues with other plugins, such as SurfTimer:
```
L 11/10/2021 - 04:43:24: [SM] Exception reported: Unable to execute a new message, there is already one in progress
L 11/10/2021 - 04:43:24: [SM] Blaming: SurfTimer.smx
L 11/10/2021 - 04:43:24: [SM] Call stack trace:
L 11/10/2021 - 04:43:24: [SM]   [0] StartMessage
L 11/10/2021 - 04:43:24: [SM]   [1] Line 269, D:\Games\GFLClan\Dev\sourcemod\scripting\include\usermessages.inc::StartMessageOne
L 11/10/2021 - 04:43:24: [SM]   [2] Line 5458, d:\Games\GFLClan\Dev\SM Plugins\surftimer-custom\addons\sourcemod\scripting\surftimer/misc.sp::PrintCSGOHUDText
L 11/10/2021 - 04:43:24: [SM]   [3] Line 3871, d:\Games\GFLClan\Dev\SM Plugins\surftimer-custom\addons\sourcemod\scripting\surftimer/misc.sp::CenterHudAlive
L 11/10/2021 - 04:43:24: [SM]   [4] Line 124, d:\Games\GFLClan\Dev\SM Plugins\surftimer-custom\addons\sourcemod\scripting\surftimer/timer.sp::CKTimer1
```

As seen from the error, it appears that `c_print_to_chat_ex` is using `PbSetInt()` instead of `PbSetBool()` when setting the `chat` field for `CCSUsrMsg_SayText2`.