### PR TITLE
Pass only a single source file to spcomp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC := ../spcomp64
 INCLUDE := -i ../include -i include -i src -i sm-ripext/pawn/scripting/include
-SRCS := gflbans admin_menu commands infractions api log utils chat
+SRCS := gflbans
 SRC_FILES := $(addprefix src/, $(addsuffix .sp, $(SRCS)))
 DEPS := 
 CC_FLAGS := 

--- a/src/gflbans.sp
+++ b/src/gflbans.sp
@@ -12,6 +12,13 @@
 #include "includes/globals"
 #include "includes/api"
 #include "includes/log"
+#include "admin_menu.sp"
+#include "commands.sp"
+#include "infractions.sp"
+#include "api.sp"
+#include "log.sp"
+#include "utils.sp"
+#include "chat.sp"
 
 public Plugin myinfo = {
     name = "GFLBans",


### PR DESCRIPTION
Following https://github.com/alliedmodders/sourcepawn/pull/637, you can now only pass one source file on the spcomp command line in 1.11.

I assumed this was the cause of recent actions compile failures on 1.11, but there seems to be something else going on there with includes too. I tried looking into this but was unable to come up with anything, I've created a separate issue for tracking at #4.