### PR TITLE
Multiple bug fixes

### DIFF
--- a/src/api.sp
+++ b/src/api.sp
@@ -401,13 +401,16 @@ bool HandleCheckObj(int client, JSONObject check) {
             blocks[total_blocks] = block;
             total_blocks++;
 
-            GFLBans_ApplyPunishment(client, block, expires - GetTime());
+            // If we got here from OnClientAuthorized and they are not ingame yet, we only want to handle bans
+            if (IsClientInGame(client) || block == Block_Join)
+                GFLBans_ApplyPunishment(client, block, expires - GetTime());
         }
     }
     delete keys;
 
     if (total_blocks > 0) {
-        GFLBans_ClearOtherPunishments(client, blocks, total_blocks);
+        if (IsClientInGame(client))
+            GFLBans_ClearOtherPunishments(client, blocks, total_blocks);
         return true;
     } else {
         return false;

--- a/src/commands.sp
+++ b/src/commands.sp
@@ -27,7 +27,7 @@ void GFLBans_RegisterCommands() {
 }
 
 public Action CommandWarn(int client, int args) {
-    int target_list[MAXPLAYERS];
+    int target_list[MAXPLAYERS+1];
     int target_count = -1;
     char reason[128];
     int time = 0;
@@ -50,7 +50,7 @@ public Action CommandAbort(int client, int args) {
 }
 
 public Action CommandBan(int client, int args) {
-    int target_list[MAXPLAYERS];
+    int target_list[MAXPLAYERS+1];
     int target_count = -1;
     char reason[128];
     int time = 0;
@@ -103,7 +103,7 @@ public Action CommandClaimCallAdmin(int client, int args) {
 }
 
 public Action CommandBanCallAdmin(int client, int args) {
-    int target_list[MAXPLAYERS];
+    int target_list[MAXPLAYERS+1];
     int target_count = -1;
     char reason[128];
     int time = 0;
@@ -140,7 +140,7 @@ bool GetCommandTargets(int client, const char[] target_string, int[] target_list
     return true;
 }
 
-bool ParseCommandArguments(const char[] command, int client, int target_list[MAXPLAYERS], int &target_count, char[] reason, int reason_max, int &time) {
+bool ParseCommandArguments(const char[] command, int client, int target_list[MAXPLAYERS+1], int &target_count, char[] reason, int reason_max, int &time) {
     if (GetCmdArgs() < 2) {
         ReplyToCommand(client, "%t", "Infraction Usage", command);
         return false;
@@ -152,7 +152,7 @@ bool ParseCommandArguments(const char[] command, int client, int target_list[MAX
     char target[65];
     int len = BreakString(arguments, target, sizeof(target));
 
-    if (!GetCommandTargets(client, target, target_list, MAXPLAYERS, target_count)) {
+    if (!GetCommandTargets(client, target, target_list, MAXPLAYERS+1, target_count)) {
         return false;
     }
 
@@ -175,7 +175,7 @@ Action HandleChatInfraction(const char[] command, int client, int admin_flags, c
         return Plugin_Continue;
     }
 
-    int target_list[MAXPLAYERS];
+    int target_list[MAXPLAYERS+1];
     int target_count = -1;
     char reason[128];
     int time = 0;
@@ -208,9 +208,9 @@ Action HandleRemoveChatInfraction(int client, int admin_flags, const InfractionB
     }
     Format(reason, sizeof(reason), arguments[len]);
 
-    int target_list[MAXPLAYERS];
+    int target_list[MAXPLAYERS+1];
     int target_count = -1;
-    if (!GetCommandTargets(client, target, target_list, MAXPLAYERS, target_count)) {
+    if (!GetCommandTargets(client, target, target_list, MAXPLAYERS+1, target_count)) {
         return Plugin_Stop;
     }
 

--- a/src/gflbans.sp
+++ b/src/gflbans.sp
@@ -94,6 +94,9 @@ public void OnClientAuthorized(int client, const char[] auth) {
 }
 
 public void OnClientPostAdminCheck(int client) {
+    if (!IsFakeClient(client)) {
+        GFLBansAPI_CheckClient(client);
+    }
     if (AreClientCookiesCached(client)) {
         OnClientCookiesCached(client);
     }

--- a/src/infractions.sp
+++ b/src/infractions.sp
@@ -174,6 +174,7 @@ void GFLBans_KillPunishmentTimers(int client) {
     for (int c = 0; c < max_blocks; c++) {
         if (player_infractions[client].infraction_timer[c] != INVALID_HANDLE) {
             KillTimer(player_infractions[client].infraction_timer[c], true);
+            player_infractions[client].infraction_timer[c] = INVALID_HANDLE;
         }
     }
 }

--- a/src/infractions.sp
+++ b/src/infractions.sp
@@ -17,7 +17,7 @@ enum struct PlayerInfractions {
     bool call_admin_banned;
 }
 
-PlayerInfractions player_infractions[MAXPLAYERS];
+PlayerInfractions player_infractions[MAXPLAYERS+1];
 
 bool GFLBans_CallAdminBanned(int client) {
     if (!GFLBans_ValidClient(client)) {

--- a/src/log.sp
+++ b/src/log.sp
@@ -11,7 +11,7 @@ LogLevel current_log_level = LogLevel_None;
 ConVar cvar_log_level;
 Cookie log_level_cookie;
 
-ClientLogState client_logs[MAXPLAYERS];
+ClientLogState client_logs[MAXPLAYERS+1];
 
 void GFLBans_InitLogging() {
     cvar_log_level = CreateConVar("gflbans_log_level", "info", "GFLBans logging level");


### PR DESCRIPTION
- Use correct size for MAXPLAYERS arrays, given a MAXPLAYERS value of 64, we'd actually want 65 because index 0 will not be used when client indexes start at 1
- Fixed GFLBans_KillPunishmentTimers leaving bad handle references in player_infractions.infraction_timer
```
[SM] Exception reported: Invalid timer handle 91e005bf (error 1)
[SM] Blaming: GFL/gflbans.smx
[SM] Call stack trace:
[SM]   [0] KillTimer
[SM]   [1] Line 199, src/infractions.sp::SetupExpirationTimer
[SM]   [2] Line 45, src/infractions.sp::GFLBans_ApplyPunishment
[SM]   [3] Line 415, src/api.sp::HandleCheckObj
[SM]   [4] Line 282, src/api.sp::HTTPCallback_CheckPlayer
```
- Fixed errors due to client not being ingame during GFLBansAPI_CheckClient
```
[SM] Exception reported: Client 1 is not in game
[SM] Blaming: basecomm.smx
[SM] Call stack trace:
[SM]   [0] ThrowNativeError
[SM]   [1] Line 44, basecomm/natives.sp::Native_IsClientGagged
[SM]   [3] BaseComm_IsClientGagged
[SM]   [4] Line 52, src/infractions.sp::GFLBans_ApplyPunishment
[SM]   [5] Line 415, src/api.sp::HandleCheckObj
[SM]   [6] Line 282, src/api.sp::HTTPCallback_CheckPlayer
```
This function is now double called in OnClientPostAdminCheck/OnClientAuthorized to preserve fast kicks via Authorized when the client is banned, and PostAdminCheck to handle everything else when the client is actually ingame.