### PR TITLE
Miscellaneous changes for SM 1.11

### DIFF
--- a/.github/workflows/sourcemod.yml
+++ b/.github/workflows/sourcemod.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        SM_VERSION: ["1.10", "1.11"]
+        SM_VERSION: ["1.11", "1.12"]
         
     steps:
       - uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,5 @@
 CC := ../spcomp64
-ifeq ($(includePath),)
-includePath := ../include
-endif
-INCLUDE := -i $(includePath) -i include -i src -i sm-ripext/pawn/scripting/include
+INCLUDE := -i src -i sm-ripext/pawn/scripting/include
 SRCS := gflbans
 SRC_FILES := $(addprefix src/, $(addsuffix .sp, $(SRCS)))
 DEPS := 

--- a/src/admin_menu.sp
+++ b/src/admin_menu.sp
@@ -1,3 +1,6 @@
+#pragma semicolon 1
+#pragma newdecls required
+
 #include <sourcemod>
 #include <adminmenu>
 #include "includes/chat"

--- a/src/api.sp
+++ b/src/api.sp
@@ -14,6 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#pragma semicolon 1
+#pragma newdecls required
+
 #include <sourcemod>
 #include <ripext>
 #include "includes/globals"

--- a/src/chat.sp
+++ b/src/chat.sp
@@ -1,3 +1,6 @@
+#pragma semicolon 1
+#pragma newdecls required
+
 #include <sourcemod>
 #include "includes/utils"
 #include "includes/chat"

--- a/src/commands.sp
+++ b/src/commands.sp
@@ -14,6 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#pragma semicolon 1
+#pragma newdecls required
+
 #include <sourcemod>
 #include "includes/infractions"
 #include "includes/utils"

--- a/src/gflbans.sp
+++ b/src/gflbans.sp
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #pragma semicolon 1
+#pragma newdecls required
 
 #include <sourcemod>
 #include <adminmenu>

--- a/src/includes/admin_menu.inc
+++ b/src/includes/admin_menu.inc
@@ -14,6 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#pragma semicolon 1
+#pragma newdecls required
+
 #if defined SPCOMP
     #endinput
 #endif

--- a/src/includes/api.inc
+++ b/src/includes/api.inc
@@ -14,6 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#pragma semicolon 1
+#pragma newdecls required
+
 #if defined SPCOMP
     #endinput
 #endif

--- a/src/includes/chat.inc
+++ b/src/includes/chat.inc
@@ -14,6 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#pragma semicolon 1
+#pragma newdecls required
+
 #if defined SPCOMP
     #endinput
 #endif

--- a/src/includes/commands.inc
+++ b/src/includes/commands.inc
@@ -14,6 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#pragma semicolon 1
+#pragma newdecls required
+
 #if defined SPCOMP
     #endinput
 #endif

--- a/src/includes/gflbans.inc
+++ b/src/includes/gflbans.inc
@@ -14,6 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#pragma semicolon 1
+#pragma newdecls required
+
 #if defined SPCOMP
     #endinput
 #endif

--- a/src/includes/globals.inc
+++ b/src/includes/globals.inc
@@ -14,6 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#pragma semicolon 1
+#pragma newdecls required
+
 #if defined _gflbans_globals_include
     #endinput
 #endif

--- a/src/includes/infractions.inc
+++ b/src/includes/infractions.inc
@@ -14,6 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#pragma semicolon 1
+#pragma newdecls required
+
 #if defined _gflbans_infractions_include
     #endinput
 #endif

--- a/src/includes/log.inc
+++ b/src/includes/log.inc
@@ -14,6 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#pragma semicolon 1
+#pragma newdecls required
+
 #if defined _gflbans_log_include
     #endinput
 #endif

--- a/src/includes/utils.inc
+++ b/src/includes/utils.inc
@@ -14,6 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#pragma semicolon 1
+#pragma newdecls required
+
 #if defined _gflbans_utils_include
     #endinput
 #endif

--- a/src/infractions.sp
+++ b/src/infractions.sp
@@ -14,6 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#pragma semicolon 1
+#pragma newdecls required
+
 #include <sourcemod>
 #include <basecomm>
 #include "includes/infractions"
@@ -129,7 +132,7 @@ void GFLBans_ClearOtherPunishments(int client, const InfractionBlock[] blocks, i
     GFLBans_RemovePunishments(client, blocks_to_clear, total_blocks_to_clear);
 }
 
-void GFLBans_ClearPunishments(client) {
+void GFLBans_ClearPunishments(int client) {
     InfractionBlock blocks_to_clear[Block_None];
     int max_blocks = view_as<int>(Block_None);
     for (int c = 0; c < max_blocks; c++) {

--- a/src/log.sp
+++ b/src/log.sp
@@ -1,3 +1,6 @@
+#pragma semicolon 1
+#pragma newdecls required
+
 #include <sourcemod>
 #include <clientprefs>
 #include "includes/log"

--- a/src/utils.sp
+++ b/src/utils.sp
@@ -14,6 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#pragma semicolon 1
+#pragma newdecls required
+
 #include <sourcemod>
 
 bool GFLBans_ValidClient(int client) {


### PR DESCRIPTION
- Target builds for SM's new stable and dev branches (1.11 and 1.12), 1.10 is now unsupported
- Clean up include management in Makefile, since https://github.com/rumblefrog/setup-sp/issues/5 has since been fixed.
- Move semicolon pragma to each file due to [1.11's pragma changes](https://github.com/alliedmodders/sourcepawn/blob/master/docs/upgrading-1.11.md#pragma-changes) making it no longer affect subfiles anymore
- Enforce newdecls pragma for cleaner code and better compatibility with new SourcePawn changes going forward
- Fixed an untagged argument in GFLBans_ClearPunishments revealed by adding newdecls pragma