### PR TITLE
Resolve GitHub actions warnings

### DIFF
--- a/.github/workflows/sourcemod.yml
+++ b/.github/workflows/sourcemod.yml
@@ -14,7 +14,7 @@ jobs:
         SM_VERSION: ["1.11", "1.12"]
         
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: Setup SourcePawn Compiler ${{ matrix.SM_VERSION }}
@@ -25,7 +25,7 @@ jobs:
         id: vars
         run: |
           SHORT_SHA=$(git rev-parse --short HEAD)
-          echo "::set-output name=plugin_version::${{ matrix.SM_VERSION }}.$SHORT_SHA"
+          echo "plugin_version=${{ matrix.SM_VERSION }}.$SHORT_SHA" >> $GITHUB_OUTPUT
       - name: Compile 
         run: |
           make CC=spcomp64 gflbans
@@ -41,7 +41,7 @@ jobs:
           cp -r gamedata/ bundle/addons/sourcemod
           cp -r configs/ bundle/addons/sourcemod
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: gflbans.${{ steps.vars.outputs.plugin_version }}
           path: ./bundle


### PR DESCRIPTION
As seen on [the latest runs](https://github.com/GFLClan/sm_gflbans/actions/runs/3288151637)
![image](https://user-images.githubusercontent.com/6075172/197004515-f513d483-05f4-4d2a-be63-9f3baf78574f.png)

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

This still doesn't resolve all of the set-output warnings, as it seems like setup-sp is using it upstream too.