### PR TITLE
Add debug logging for LogResponseError HTTP status code

### DIFF
--- a/scripting/gflbans/api.sp
+++ b/scripting/gflbans/api.sp
@@ -387,19 +387,21 @@ public void HTTPCallback_RemoveInfraction(HTTPResponse response, any data, const
 }
 
 void LogResponseError(const char[] action, HTTPResponse response, const char[] error) {
-        JSONObject data = view_as<JSONObject>(response.Data);
-        char detail[128];
-        detail[0] = '\0';
-        if (data.HasKey("detail")) {
-            data.GetString("detail", detail, sizeof(detail));
-        }
-        GFLBans_LogError(
-            "API Error %s;\n -> unexpected status code %d\n -> client error: %s\n -> detail: %s", 
-            action, 
-            response.Status, 
-            error, 
-            detail
-        );
+    // We can't always print the status code further below if the API returns invalid JSON and causes an exception
+    GFLBans_LogDebug("Status code %i beginning a LogResponseError call", response.Status);
+    JSONObject data = view_as<JSONObject>(response.Data);
+    char detail[128];
+    detail[0] = '\0';
+    if (data.HasKey("detail")) {
+        data.GetString("detail", detail, sizeof(detail));
+    }
+    GFLBans_LogError(
+        "API Error %s;\n -> unexpected status code %d\n -> client error: %s\n -> detail: %s", 
+        action, 
+        response.Status, 
+        error, 
+        detail
+    );
 }
 
 bool HandleCheckObj(int client, JSONObject check) {

--- a/scripting/gflbans/log.sp
+++ b/scripting/gflbans/log.sp
@@ -23,7 +23,7 @@ Cookie log_level_cookie;
 ClientLogState client_logs[MAXPLAYERS+1];
 
 void GFLBans_InitLogging() {
-    cvar_log_level = CreateConVar("gflbans_log_level", "info", "GFLBans logging level");
+    cvar_log_level = CreateConVar("gflbans_log_level", "info", "GFLBans logging level. Accepts error, warn, info or debug");
     cvar_log_level.AddChangeHook(Cvar_LogLevelChanged);
     RegAdminCmd("sm_gflbans_showlogs", CommandShowLogs, ADMFLAG_RCON);
     log_level_cookie = new Cookie("gflbans_log_level", "", CookieAccess_Private);


### PR DESCRIPTION
Helps with testing/dev, some examples of this.
```
L 05/13/2023 - 00:53:01: [SM] Exception reported: Invalid JSON in line 1, column 8: '[' or '{' expected near 'Internal'
L 05/13/2023 - 00:53:01: [SM] Blaming: GFL/gflbans.smx
L 05/13/2023 - 00:53:01: [SM] Call stack trace:
L 05/13/2023 - 00:53:01: [SM]   [0] HTTPResponse.Data.get
L 05/13/2023 - 00:53:01: [SM]   [1] Line 390, gflbans\api.sp::LogResponseError
L 05/13/2023 - 00:53:01: [SM]   [2] Line 372, gflbans\api.sp::HTTPCallback_SaveInfraction
```
```
L 05/13/2023 - 01:37:29: [SM] Exception reported: Invalid JSON in line 1, column 1: '[' or '{' expected near '<'
L 05/13/2023 - 01:37:29: [SM] Blaming: GFL/gflbans.smx
L 05/13/2023 - 01:37:29: [SM] Call stack trace:
L 05/13/2023 - 01:37:29: [SM]   [0] HTTPResponse.Data.get
L 05/13/2023 - 01:37:29: [SM]   [1] Line 391, gflbans\api.sp::LogResponseError
L 05/13/2023 - 01:37:29: [SM]   [2] Line 359, gflbans\api.sp::HTTPCallback_Heartbeat
```
Ideally fixable on API-side by returning all errors as proper JSON, but will still be good to have.