### PR TITLE
Display "Console" instead of hostname when server punishes someone

### DIFF
--- a/scripting/gflbans/chat.sp
+++ b/scripting/gflbans/chat.sp
@@ -3,8 +3,13 @@
 
 void GFLBansChat_AnnounceAction(int client, int target, const InfractionBlock[] blocks, int total_blocks, int duration) {
     char admin[64], targ[64], s_duration[32], translation_str[12];
-    GetClientName(client, admin, sizeof(admin));
     GetClientName(target, targ, sizeof(targ));
+
+    if (client == 0)
+        admin = "Console";
+    else
+        GetClientName(client, admin, sizeof(admin));
+
     for (int c = 1; c <= MaxClients; c++) {
         if (IsClientConnected(c) && !IsFakeClient(c)) {
             GFLBans_FormatDuration(c, duration, s_duration, sizeof(s_duration));


### PR DESCRIPTION
old
![csgo_2023-05-11_21-15-57](https://github.com/GFLClan/sm_gflbans/assets/6075172/d7484c2d-7ea5-4cf1-930a-ddce7835b506)

new
![image](https://github.com/GFLClan/sm_gflbans/assets/6075172/4657a8c4-806b-4d1f-8291-0a1c834d12f0)
